### PR TITLE
fix: adoc header

### DIFF
--- a/documentation/modelling-decisions.adoc
+++ b/documentation/modelling-decisions.adoc
@@ -3,7 +3,7 @@
 :author: Michael Hunger
 :tags: network-mgt,it-operations,datacenter
 :images: https://dl.dropboxusercontent.com/u/14493611
-:images: {img}
+:images: img
 :experimental:
 
 Computer networks span all levels of the stack from physical connections up to mobile and web-applications connecting networks of users.

--- a/documentation/network-management.adoc
+++ b/documentation/network-management.adoc
@@ -14,7 +14,7 @@
 :author: Michael Hunger
 :tags: network-mgt,it-operations,datacenter
 :images: https://dl.dropboxusercontent.com/u/14493611
-:images: {img}
+:images: img
 :experimental:
 
 Computer networks span all levels of the stack from physical connections up to mobile and web-applications connecting networks of users.


### PR DESCRIPTION
Thank you for the great documentation.

The current .adoc file headers were causing many images to appear as broken links when viewed on Github,  
so I fixed this in this PR.
(The modified header is the same as in [ref.](https://github.com/neo4j-graph-examples/cybersecurity/blob/7c733721deec21066ad17a393b69718132f2026e/documentation/cybersecurity.adoc?plain=1#L11
))

|Before|After|
|---|---|
![image](https://github.com/user-attachments/assets/abfa7723-327f-438a-9d4b-0a20d7ce2486)|![image](https://github.com/user-attachments/assets/9477c82b-c288-46e1-ab9c-a0e6abebc856)
|
